### PR TITLE
isp: define ispTransmit in .c

### DIFF
--- a/firmware/isp.c
+++ b/firmware/isp.c
@@ -17,6 +17,7 @@
 
 uchar sck_sw_delay;
 uchar isp_hiaddr;
+uchar (*ispTransmit)(uchar);
 
 static inline void spiHWenable() {
     /* enable SPI, master */

--- a/firmware/isp.h
+++ b/firmware/isp.h
@@ -57,7 +57,7 @@ uchar ispReadFlash(unsigned long address);
 uchar ispWriteEEPROM(unsigned int address, uchar data);
 
 /* pointer to sw or hw transmit function */
-uchar (*ispTransmit)(uchar);
+extern uchar (*ispTransmit)(uchar);
 
 /* set SCK speed. call before ispConnect! */
 void ispSetSCKOption(uchar sckoption);


### PR DESCRIPTION
I see:
```
/usr/lib64/gcc/avr/15/ld: main.o:(.bss+0x1): multiple definition of `ispTransmit'; isp.o:(.bss+0x2): first defined here 
collect2: error: ld returned 1 exit status
```

I am not sure how this could ever work. Variables belong to .c, so move `ispTransmit` to isp.c and add a declaration (`extern`) to .h.