### PR TITLE
The firmware requires both Read and Write callbacks regardless of HIDUART 

### DIFF
--- a/firmware/usbconfig.h
+++ b/firmware/usbconfig.h
@@ -138,20 +138,12 @@ section at the end of this file).
  * The value is in milliamperes. [It will be divided by two since USB
  * communicates power requirements in units of 2 mA.]
  */
-#ifdef __HIDUART__
 #define USB_CFG_IMPLEMENT_FN_WRITE      1
-#else
-#define USB_CFG_IMPLEMENT_FN_WRITE      0
-#endif    
 /* Set this to 1 if you want usbFunctionWrite() to be called for control-out
  * transfers. Set it to 0 if you don't need it and want to save a couple of
  * bytes.
  */
-#ifdef __HIDUART__
 #define USB_CFG_IMPLEMENT_FN_READ       1
-#else
-#define USB_CFG_IMPLEMENT_FN_READ       0
-#endif    
 /* Set this to 1 if you need to send control replies which are generated
  * "on the fly" when usbFunctionRead() is called. If you only want to send
  * data from a static buffer, set it to 0 and return the data from


### PR DESCRIPTION
When I build without HIDUART like this,
`make TPI=1  main.hex`
it does not function properly and consistently fails to program a target.

The patch resolves the issue.

BTW, thanks for all the efforts you put into this.
this is what I've been hoping to have for a long time. I mean, MS OS 2.0 WCID is the best.